### PR TITLE
Added luacheck config file, install luacheck and run it

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,24 @@
+-- This file is the config file for the tool named Luacheck
+-- Documentation: http://luacheck.readthedocs.io/en/stable/index.html
+
+-- Ignore unused function and loop arguments
+unused_args = false
+
+-- Allow self defined globals
+allow_defined = true
+
+-- Ignore files / directories
+exclude_files =
+{
+	"tests/",  -- CuberitePluginChecker
+}
+
+-- Ignore variables, warning codes
+ignore =
+{
+	"113",  -- Accessing an undefined global variable.
+	"211",  -- Unused local variable.
+	"421",  -- Shadowing a local variable.
+	"432",  -- Shadowing an upvalue argument.
+	"511",  -- Unreachable code.
+}

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ dependencies:
   - sudo luarocks install lsqlite3
   - sudo luarocks install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu
   - sudo luarocks install luasocket
+  - sudo luarocks install luacheck
   - git clone --depth=1 https://github.com/cuberite/gallery ~/Gallery
   - wget -O ~/InfoReg.lua https://raw.githubusercontent.com/cuberite/cuberite/master/Server/Plugins/InfoReg.lua
   - mkdir ~/AutoAPI
@@ -20,3 +21,4 @@ dependencies:
 test:
  override:
   - lua CuberitePluginChecker.lua -p ~/Gallery -a ~/AutoAPI -e ~/ManualAPI.lua -i APIImpl/All.lua -s tests/Gallery/FuzzCommands.lua
+  - luacheck -q .


### PR DESCRIPTION
This adds luacheck to test the source files from CuberitePluginChecker. Closes #26 

@madmaxoft You said that commands in test/overrides can run parallel. Do I only need to change the line?
```
lua CuberitePluginChecker.lua -p ~/Gallery -a ~/AutoAPI -e ~/ManualAPI.lua -i APIImpl/All.lua -s tests/Gallery/FuzzCommands.lua
```
to
```
lua CuberitePluginChecker.lua -p ~/Gallery -a ~/AutoAPI -e ~/ManualAPI.lua -i APIImpl/All.lua -s tests/Gallery/FuzzCommands.lua && luacheck -q .
```