### PR TITLE
Added redirectPluginFiles action

### DIFF
--- a/Scenario.lua
+++ b/Scenario.lua
@@ -10,19 +10,21 @@ that has an "execute" member that provides the function that is to be called. It
 the Simulator instance.
 
 Actions:
-	- loadPluginFiles   -- Loads all the plugin files and executes the globals
-	- initializePlugin  -- Calls the Initialize function. If not loaded, loads the plugin files first.
-	- world             -- Creates a new world
-	- playerConnect     -- Simulates a new player connecting to the server
-	- playerCommand     -- Simulates a player executing a command
-	- fuzzAllCommands   -- Simulates a player executing each command with a wide range of parameters (fuzzing)
-	- fsCreateFile      -- Creates a file, possibly with content
-	- fsCopyFile        -- Copies a file
-	- fsRenameFile      -- Renames a file
-	- fsDeleteFile      -- Deletes a file
-	- fsCreateFolder    -- Creates a new folder (recursive)
-	- fsRenameFolder    -- Renames an existing folder
-	- fsDeleteFolder    -- Deletes a folder (optionally recursive
+	- redirect            -- Adds redirection for files and folders.
+	- redirectPluginFiles -- Redirects files inside the plugin folder.
+	- loadPluginFiles     -- Loads all the plugin files and executes the globals
+	- initializePlugin    -- Calls the Initialize function. If not loaded, loads the plugin files first.
+	- world               -- Creates a new world
+	- playerConnect       -- Simulates a new player connecting to the server
+	- playerCommand       -- Simulates a player executing a command
+	- fuzzAllCommands     -- Simulates a player executing each command with a wide range of parameters (fuzzing)
+	- fsCreateFile        -- Creates a file, possibly with content
+	- fsCopyFile          -- Copies a file
+	- fsRenameFile        -- Renames a file
+	- fsDeleteFile        -- Deletes a file
+	- fsCreateFolder      -- Creates a new folder (recursive)
+	- fsRenameFolder      -- Renames an existing folder
+	- fsDeleteFolder      -- Deletes a folder (optionally recursive
 
 Example scenario file:
 scenario
@@ -57,6 +59,18 @@ local function sandboxRedirect(a_Table)
 	-- Return the action implementation:
 	return function(a_Simulator)
 		a_Simulator:addRedirects(a_Table)
+	end
+end
+
+
+
+
+
+--- Sandbox handler of the redirectPluginFiles keyword.
+-- Returns an action that adds the redirection inside the simulator.
+local function sandboxRedirectPluginFiles(a_Table)
+	return function (a_Simulator)
+		a_Simulator:addRedirectPluginFiles(a_Table)
 	end
 end
 
@@ -529,6 +543,7 @@ local scenarioSandbox =
 {
 	scenario               = nil,  -- Will be explicitly modified for each file being loaded
 	redirect               = sandboxRedirect,
+	redirectPluginFiles    = sandboxRedirectPluginFiles,
 	world                  = sandboxWorld,
 	connectPlayer          = sandboxConnectPlayer,
 	playerCommand          = sandboxPlayerCommand,

--- a/ScenarioFiles.md
+++ b/ScenarioFiles.md
@@ -56,15 +56,16 @@ Adds a redirection for files inside the plugin folder. All Cuberite APIs that ta
 
 Key provided in dictionary | Value provided in dictionary | Path provided by plugin | Path actually used
 ---------------------------|------------------------------|-------------------------|-------------------
-config.cfg                 | tests/config.cfg             | Plugins/[myplugin]/config.cfg | Plugins/[myplugin]/tests/config.cfg
-Classes/Storage.lua        | tests/Storage.mock.lua      | Plugins/[myplugin]/Classes/Storage.lua | Plugins/[myplugin]/tests/Storage.mock.lua
+config.cfg                 | config.cfg             | Plugins/[myplugin]/config.cfg | [scenarioPath]/config.cfg
+Classes/Storage.lua        | mocks/Storage.lua      | Plugins/[myplugin]/Classes/Storage.lua | [scenarioPath]/mocks/Storage.lua
 
 Takes a dictionary table which maps the old paths to the new paths.
 
 ```lua
 redirectPluginFiles
 {
-	["config.cfg"] = "tests/config.cfg"
+	-- Redirect the 'config.cfg' file from the plugin folder to the scenario folder
+	["config.cfg"] = "config.cfg"
 }
 ```
 

--- a/ScenarioFiles.md
+++ b/ScenarioFiles.md
@@ -51,6 +51,23 @@ Takes a dictionary table which maps old paths to new paths as its parameter. Not
 }
 ```
 
+## redirectPluginFiles
+Adds a redirection for files inside the plugin folder. All Cuberite APIs that take a file or folder path check if the file needs to be redirected. This is useful if you want to use a different configuration file in your scenario. It can also be used to insert mocks in the code. The following table should make it clear how it works.
+
+Key provided in dictionary | Value provided in dictionary | Path provided by plugin | Path actually used
+---------------------------|------------------------------|-------------------------|-------------------
+config.cfg                 | tests/config.cfg             | Plugins/[myplugin]/config.cfg | Plugins/[myplugin]/tests/config.cfg
+Classes/Storage.lua        | tests/Storage.mock.lua      | Plugins/[myplugin]/Classes/Storage.lua | Plugins/[myplugin]/tests/Storage.mock.lua
+
+Takes a dictionary table which maps the old paths to the new paths.
+
+```lua
+redirectPluginFiles
+{
+	["config.cfg"] = "tests/config.cfg"
+}
+```
+
 ## world
 Adds a new world. Usually used before plugin initialization to set up the worlds, but can also be used later. It triggers the `HOOK_WORLD_STARTED` hook properly. If a world of the specified name already exists, the Checker aborts with an error.
 

--- a/Simulator.lua
+++ b/Simulator.lua
@@ -130,6 +130,22 @@ end
 
 
 
+--- Adds the specified file / folder redirection.
+-- Only redirects files inside the plugin folder.
+function Simulator:addRedirectPluginFiles(a_Redirects)
+	assert(self)
+	assert(type(a_Redirects) == "table")
+
+	-- Add the redirects.
+	for orig, new in pairs(a_Redirects) do
+		table.insert(self.redirectPluginFiles, { original = self.options.pluginPath .. "/" .. orig, new = new })
+	end
+end
+
+
+
+
+
 --- Called by the simulator after calling the callback, when the ClearObjects is specified in the options
 -- a_Params is an array-table of the params that were given to the callback
 -- a_Returns is an array-table of the return values that the callback returned
@@ -1330,6 +1346,14 @@ function Simulator:paramTypesMatch(a_ParamType, a_SignatureType)
 		if (self.enums[a_SignatureType]) then
 			return true
 		end
+
+		-- The param doesn't match up.
+		return false
+	end
+
+	-- If the signature didn't match and it isn't a class which could inherit the signature return "incompatible":
+	if ((a_ParamType == "string") or (a_ParamType == "function")) then
+		return false
 	end
 
 	-- If both types are classes and the param is a descendant of signature, return "compatible":
@@ -1426,6 +1450,15 @@ function Simulator:redirectPath(a_Path)
 	assert(type(a_Path) == "string")
 
 	a_Path = self:collapseRelativePath(a_Path)
+
+	-- Check for files to redirect from inside the plugin folder.
+	for idx, redirect in ipairs(self.redirectPluginFiles) do
+		if (a_Path == redirect.original) then
+			local res = self.options.pluginPath .. "/" .. redirect.new
+			self.logger:trace(string.format("Redirecting \"%s\" to \"%s\".", a_Path, res))
+			return res;
+		end
+	end
 
 	-- If there is a matching entry in the redirects, use it:
 	local match = self.redirects[a_Path]
@@ -1699,6 +1732,9 @@ local function createSimulator(a_Options, a_Logger)
 
 		-- A dictionary of file / folder redirections. Maps the original path to the new path.
 		redirects = {},
+
+		-- An array containing redirects specifically from inside the plugins folder.
+		redirectPluginFiles = {},
 
 		-- State manipulated through scenarios:
 		worlds = {},

--- a/Simulator.lua
+++ b/Simulator.lua
@@ -138,7 +138,10 @@ function Simulator:addRedirectPluginFiles(a_Redirects)
 
 	-- Add the redirects.
 	for orig, new in pairs(a_Redirects) do
-		table.insert(self.redirectPluginFiles, { original = self.options.pluginPath .. "/" .. orig, new = new })
+		table.insert(self.redirectPluginFiles, {
+			original = self.options.pluginPath .. "/" .. orig,
+			new = self.options.scenarioPath .. "/" .. new
+		})
 	end
 end
 
@@ -1454,9 +1457,8 @@ function Simulator:redirectPath(a_Path)
 	-- Check for files to redirect from inside the plugin folder.
 	for idx, redirect in ipairs(self.redirectPluginFiles) do
 		if (a_Path == redirect.original) then
-			local res = self.options.pluginPath .. "/" .. redirect.new
-			self.logger:trace(string.format("Redirecting \"%s\" to \"%s\".", a_Path, res))
-			return res;
+			self.logger:trace(string.format("Redirecting \"%s\" to \"%s\".", a_Path, redirect.new))
+			return redirect.new;
 		end
 	end
 


### PR DESCRIPTION
`redirectPluginFiles` is an action similar to `redirect` which allows you to redirect paths to another path. `redirectPluginFiles` only looks at files inside the plugin's folder.

Also fixed bug where the simulator would check the inheritance of strings and functions.


The following has been added to the ScenarioFiles.md file:
## redirectPluginFiles
Adds a redirection for files inside the plugin folder. All Cuberite APIs that take a file or folder path check if the file needs to be redirected. This is useful if you want to use a different configuration file in your scenario. It can also be used to insert mocks in the code. The following table should make it clear how it works.

Key provided in dictionary | Value provided in dictionary | Path provided by plugin | Path actually used
---------------------------|------------------------------|-------------------------|-------------------
config.cfg                 | config.cfg             | Plugins/[myplugin]/config.cfg | [scenarioPath]/config.cfg
Classes/Storage.lua        | mocks/Storage.lua      | Plugins/[myplugin]/Classes/Storage.lua | [scenarioPath]/mocks/Storage.lua

Takes a dictionary table which maps the old paths to the new paths.

```lua
redirectPluginFiles
{
	-- Redirect the 'config.cfg' file from the plugin folder to the scenario folder
	["config.cfg"] = "config.cfg"
}
```